### PR TITLE
Accept options to be metalsmith cli-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,28 @@ metalsmith(__dirname)
   .use(b) // use the plugin
   .build()
 ```
+
+It can also be used with `metalsmith.json` by adding the plugin like this:
+
+```json
+{
+  "plugins": {
+    "metalsmith-browserify": {
+      "dest": "javascripts/bundle.js",
+      "args": ["src/javascripts/index.js"]
+    }
+  }
+}
+```
+
+Or assume the defaults (dest: `bundle.js`, args: []):
+
+```json
+{
+  "plugins": {
+    "metalsmith-browserify": true
+  }
+}
+```
+
+

--- a/index.js
+++ b/index.js
@@ -2,9 +2,24 @@
 
 var browserify = require('browserify');
 
-module.exports = function (dest) {
-  var args = Array.from(arguments);
-  args.shift();
+var defaultDest = 'bundle.js';
+
+module.exports = function (options) {
+  var args = Array.prototype.slice.call(arguments, 1);
+  var dest = options;
+
+  if (typeof options == 'object') {
+    if ('args' in options) {
+      args = options.args;
+    }
+    if ('dest' in options) {
+      dest = options.dest;
+    }
+  }
+
+  if (typeof dest !== 'string') {
+    dest = 'bundle.js';
+  }
 
   var b = browserify.apply(browserify, args);
 

--- a/index.test.js
+++ b/index.test.js
@@ -10,7 +10,7 @@ describe('metalsmith-browserify', function () {
   it('should bundle js files', function (done) {
     metalsmith(__dirname)
       .source('./fixtures/src')
-      .use(browserify('bundle.js'), [
+      .use(browserify('bundle-file.js'), [
         './fixtures/js/index.js'
       ])
       .build(function (err) {
@@ -18,7 +18,56 @@ describe('metalsmith-browserify', function () {
           return done(err);
         }
 
+        expect(fs.existsSync('./build/bundle-file.js')).to.be(true);
+        fs.unlinkSync('./build/bundle-file.js');
+        done();
+      });
+  });
+
+  it('should accept options', function (done) {
+    metalsmith(__dirname)
+      .source('./fixtures/src')
+      .use(browserify({
+        dest: 'bundle-options.js',
+        args: ['./fixtures/js/index.js']
+      }))
+      .build(function (err) {
+        if (err) {
+          return done(err);
+        }
+
+        expect(fs.existsSync('./build/bundle-options.js')).to.be(true);
+        fs.unlinkSync('./build/bundle-options.js');
+        done();
+      });
+  });
+
+  it('should have reasonable default options', function (done) {
+    metalsmith(__dirname)
+      .source('./fixtures/src')
+      .use(browserify())
+      .build(function (err) {
+        if (err) {
+          return done(err);
+        }
+
         expect(fs.existsSync('./build/bundle.js')).to.be(true);
+        fs.unlinkSync('./build/bundle.js');
+        done();
+      });
+  });
+
+  it('should accept true option', function (done) {
+    metalsmith(__dirname)
+      .source('./fixtures/src')
+      .use(browserify(true))
+      .build(function (err) {
+        if (err) {
+          return done(err);
+        }
+
+        expect(fs.existsSync('./build/bundle.js')).to.be(true);
+        fs.unlinkSync('./build/bundle.js');
         done();
       });
   });

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
     "expect.js": "^0.3.1",
     "metalsmith": "^2.1.0",
     "mocha": "^2.3.4"
+  },
+  "peerDependencies": {
+    "browserify": "*",
+    "metalsmith": "*"
   }
 }


### PR DESCRIPTION
I like to use my metalsmith plugins with the `metalsmith.json` and noticed this plugin needed a little update.

This PR shouldn't break previous usage but also accept an options object, similar to other plugins.

Thanks!
