### PR TITLE
Inject bundled JS into files array

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,6 @@ metalsmith(__dirname)
 
 See [browserify api](https://www.npmjs.com/package/browserify#api-example) for available options.
 
-If you need to manipulate the created browserify bundle do:
-
-```javascript
-var metalsmith = require('metalsmith');
-var browserify = require('metalsmith-browserify');
-
-var b = browserify({
-  dest: 'js/bundle.js',
-  entires: ['./src/js/index.js']
-);
-
-// do stuff with the bundle
-b.bundle.external(/*...*/);
-
-metalsmith(__dirname)
-  .use(b) // use the plugin
-  .build()
-```
-
 It can also be used with `metalsmith.json` by adding the plugin like this:
 
 ```json

--- a/index.js
+++ b/index.js
@@ -44,20 +44,23 @@ module.exports = function (options) {
     });
 
     function create(first) {
-      var s;
       if (options.sourcemaps) {
-        s = b.bundle()
-        .on('error', console.error.bind(console))
-        .pipe(exorcist(bundleDest + '.map'))
-        .pipe(fs.createWriteStream(bundleDest), 'utf8');
+        b.bundle(function(err, buffer) {
+            if (err) return callback(err);
+            files[options.dest] = {
+                contents: buffer
+            };
+            callback();
+        })
+        .pipe(exorcist(bundleDest + '.map'));
       } else {
-        s = b.bundle()
-        .on('error', console.error.bind(console))
-        .pipe(fs.createWriteStream(bundleDest), 'utf8');
-      }
-
-      if (first) {
-        s.on('finish', callback);
+        b.bundle(function(err, buffer) {
+            if (err) return callback(err);
+            files[options.dest] = {
+                contents: buffer
+            };
+            callback();
+        });
       }
     }
 


### PR DESCRIPTION
Rather than bypassing the build pipeline and IMO defeating the purpose of Metalsmith, inject the newly bundled js file back into the files array. 