### PR TITLE
Fix for wrong separator in entry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,15 @@ module.exports = options => (files, metalsmith, done) => {
   }
 
   const source = metalsmith.source();
-  const promises = options.entries.map(entry => bundle({ entry, options, source, files }));
+
+  const needToFixEntry = '/' !== path.sep;
+  const promises = options.entries.map(entry => {
+    if (needToFixEntry) {
+      entry = entry.replace(/\//g, path.sep);
+    }
+    
+    return bundle({ entry, options, source, files });
+  });
 
   Promise.all(promises)
     .then(() => done())

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,13 +44,15 @@ module.exports = options => (files, metalsmith, done) => {
 
   const source = metalsmith.source();
 
-  const needToFixEntry = '/' !== path.sep;
+  const needToFixEntry = path.sep !== '/';
+
   const promises = options.entries.map(entry => {
+    let finalEntry = entry;
     if (needToFixEntry) {
-      entry = entry.replace(/\//g, path.sep);
+      finalEntry = finalEntry.replace(/\//g, path.sep);
     }
-    
-    return bundle({ entry, options, source, files });
+
+    return bundle({ finalEntry, options, source, files });
   });
 
   Promise.all(promises)

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,15 +45,9 @@ module.exports = options => (files, metalsmith, done) => {
   const source = metalsmith.source();
 
   const needToFixEntry = path.sep !== '/';
+  options.entries.map(entry => (needToFixEntry ? entry.replace(/\//g, path.sep) : entry));
 
-  const promises = options.entries.map(entry => {
-    let finalEntry = entry;
-    if (needToFixEntry) {
-      finalEntry = finalEntry.replace(/\//g, path.sep);
-    }
-
-    return bundle({ finalEntry, options, source, files });
-  });
+  const promises = options.entries.map(entry => bundle({ entry, options, source, files }));
 
   Promise.all(promises)
     .then(() => done())

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,9 @@ module.exports = options => (files, metalsmith, done) => {
   const source = metalsmith.source();
 
   const needToFixEntry = path.sep !== '/';
-  options.entries.map(entry => (needToFixEntry ? entry.replace(/\//g, path.sep) : entry));
-
-  const promises = options.entries.map(entry => bundle({ entry, options, source, files }));
+  const promises = options.entries
+    .map(entry => (needToFixEntry ? entry.replace(/\//g, path.sep) : entry))
+    .map(entry => bundle({ entry, options, source, files }));
 
   Promise.all(promises)
     .then(() => done())

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -60,6 +60,20 @@ describe('metalsmith-browserify', () => {
       });
   });
 
+  it('should fix separator in entries', done => {
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'fix-entry-separator');
+    const metalsmith = new Metalsmith(base);
+
+    return metalsmith
+      .use(plugin({ entries: ['js/index.js'], browserifyOptions: { debug: true } }))
+      .build(err => {
+        if (err) {
+          return done(err);
+        }
+        return done();
+      });
+  });
+
   it('should return an error when there is an error while bundling', done => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'bundle-error');
     const metalsmith = new Metalsmith(base);

--- a/test/fixtures/fix-entry-separator/src/js/index.js
+++ b/test/fixtures/fix-entry-separator/src/js/index.js
@@ -1,0 +1,1 @@
+console.log('something');


### PR DESCRIPTION
This PR fixes the following problem:
When plugin is  executed on Windows environment and entries contain path separator (e.g.  entries: ['js/main.js']) it will lead to a mismatch between files and entries, because in entries the separator will be "/' and in files "\".