### PR TITLE
Throw a readable error when the entry file does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can pass options to `metalsmith-browserify` with the [Javascript API](https:
 
 * [entries](#entries): required. The entry points that need to be browserified. Accepts an array of strings.
 * [browserifyOptions](#browserifyoptions): optional. These options will be passed on to browserify. See [this area of the browserify documentation](https://github.com/browserify/browserify#browserifyfiles--opts) for all available options. Note that it's possible to break stuff here, like overriding the entries or basedir, so use wisely.
+* [suppressNotFoundError](#suppressnotfounderror): optional. By default `metalsmith-browserify` will exit with an error if a file can't be found. Enabling this option will suppress that error.
 
 ### `entries`
 
@@ -68,6 +69,25 @@ Use this to pass options to browserify. So this `metalsmith.json`:
 ```
 
 Would enable browserify's debug option and add a source map to the bundle.
+
+### `suppressNotFoundError`
+
+`metalsmith-browserify` exits with an error if it can’t find an [entry file](#entries). If you’re doing any kind of incremental builds via something like `metalsmith-watch`, this is problematic as you’re likely only rebuilding files that have changed. This flag allows you to suppress that error:
+
+```json
+{
+  "source": "src",
+  "destination": "build",
+  "plugins": {
+    "metalsmith-browserify": {
+      "entries": ["index.js"],
+      "suppressNotFoundError": true
+    }
+  }
+}
+```
+
+Note that when this option is turned on, if you're logging [debug](#errors-and-debugging) messages, you’ll still see a message denoting which files metalsmith-browserify cannot find.
 
 ## Errors and debugging
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The entry points that should be browserified. So this `metalsmith.json`:
 
 Would browserify both `./src/index.js` and `./src/another.js` and output them as `./build/index.js` and `./build/another.js` respectively.
 
+Note that if the entry path is nested, the paths may differ across environments (for example, on Windows the paths may use `\` as a separator). To fix this, use the Javascript API and use `path.join` to generate the correct path for your system at runtime.
+
 ### `browserifyOptions`
 
 Use this to pass options to browserify. So this `metalsmith.json`:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The entry points that should be browserified. So this `metalsmith.json`:
 
 Would browserify both `./src/index.js` and `./src/another.js` and output them as `./build/index.js` and `./build/another.js` respectively.
 
-Note that if the entry path is nested, the paths may differ across environments (for example, on Windows the paths may use `\` as a separator). To fix this, use the Javascript API and use `path.join` to generate the correct path for your system at runtime.
+Note that if the entry path is nested, the paths may differ across operating systems. Make sure you're using the correct directory separators, or use node's [path.join](https://nodejs.org/api/path.html#path_path_join_paths) to make sure the path will work anywhere.
 
 ### `browserifyOptions`
 

--- a/lib/__snapshots__/index.test.js.snap
+++ b/lib/__snapshots__/index.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`metalsmith-browserify should return an error when entries contains a file that does not exist 1`] = `"Cannot use 'doesNotExist.js' as an entry point - file does not exist."`;
+
 exports[`metalsmith-browserify should return an error when entries is empty 1`] = `"Need at least a single entry point to process"`;
 
 exports[`metalsmith-browserify should return an error when entries is not an array 1`] = `"The entries option must be an array of strings"`;

--- a/lib/__snapshots__/index.test.js.snap
+++ b/lib/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`metalsmith-browserify should return an error when entries contains a file that does not exist 1`] = `"Cannot use 'doesNotExist.js' as an entry point - file does not exist."`;
+exports[`metalsmith-browserify should return an error when entries contains a file that does not exist 1`] = `"Can't find 'doesNotExist.js'. The file doesn't exist or the path is invalid"`;
 
 exports[`metalsmith-browserify should return an error when entries is empty 1`] = `"Need at least a single entry point to process"`;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,19 +13,24 @@ const bundle = ({ file, options, source, files }) => {
 
   const readable = new Readable();
   const filePath = path.join(source, file);
+  const fileExists = fs.existsSync(filePath);
 
-  if (!fs.existsSync(filePath)) {
-    return Promise.reject(
-      new Error(
-        `Can't find '${file}' at ${filePath}. The file doesn't exist or the path is invalid`
-      )
-    );
+  if (!fileExists) {
+    const message = `Can't find '${file}'. The file doesn't exist or the path is invalid`;
+
+    if (options.suppressNotFoundError) {
+      debug(message);
+
+      return Promise.resolve();
+    }
+
+    return Promise.reject(new Error(message));
   }
 
   const fileDir = path.parse(filePath).dir;
   const browserifyOptions = Object.assign({}, options.browserifyOptions, { basedir: fileDir });
 
-  // Push the file into the stream
+  // Add the file to the stream
   readable.push(files[file].contents);
 
   // Signal the end of the stream
@@ -66,24 +71,7 @@ module.exports = options => (files, metalsmith, done) => {
   }
 
   const source = metalsmith.source();
-
-  // remove entries that are not present in files
-  // this can happen during metalsmith-watch
-  // as only changed files are present in the files object
-  function isInFiles(file) {
-    if (!files[file]) {
-      debug(`File ${file} not found.`);
-      return false;
-    }
-
-    return true;
-  }
-
-  function bundleFile(file) {
-    return bundle({ file, options, source, files });
-  }
-
-  const promises = options.entries.filter(isInFiles).map(bundleFile);
+  const promises = options.entries.map(file => bundle({ file, options, source, files }));
 
   return Promise.all(promises)
     .then(() => done())

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,9 @@ const bundle = ({ file, options, source, files }) => {
 
   if (!fs.existsSync(filePath)) {
     return Promise.reject(
-      new Error(`Cannot use '${file}' as an entry point - file does not exist.`)
+      new Error(
+        `Can't find '${file}' at ${filePath}. The file doesn't exist or the path is invalid`
+      )
     );
   }
 
@@ -81,9 +83,7 @@ module.exports = options => (files, metalsmith, done) => {
     return bundle({ file, options, source, files });
   }
 
-  const promises = options.entries
-    .filter(isInFiles)
-    .map(bundleFile);
+  const promises = options.entries.filter(isInFiles).map(bundleFile);
 
   return Promise.all(promises)
     .then(() => done())

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const { Readable } = require('stream');
 const path = require('path');
+const fs = require('fs');
 const debug = require('debug')('metalsmith-browserify');
 const browserify = require('browserify');
 
@@ -12,6 +13,11 @@ const bundle = ({ file, options, source, files }) => {
 
   const readable = new Readable();
   const filePath = path.join(source, file);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Cannot use '${file}' as an entry point - file does not exist.`);
+  }
+
   const fileDir = path.parse(filePath).dir;
   const browserifyOptions = Object.assign({}, options.browserifyOptions, { basedir: fileDir });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,9 @@ const bundle = ({ file, options, source, files }) => {
   const filePath = path.join(source, file);
 
   if (!fs.existsSync(filePath)) {
-    throw new Error(`Cannot use '${file}' as an entry point - file does not exist.`);
+    return Promise.reject(
+      new Error(`Cannot use '${file}' as an entry point - file does not exist.`)
+    );
   }
 
   const fileDir = path.parse(filePath).dir;

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -30,9 +30,11 @@ describe('metalsmith-browserify', () => {
     const expected = path.join(base, 'expected');
     const metalsmith = new Metalsmith(base);
 
+    const entry = path.join('nested', 'index.js');
+
     rimraf.sync(actual);
 
-    return metalsmith.use(plugin({ entries: ['nested/index.js'] })).build(err => {
+    return metalsmith.use(plugin({ entries: [entry] })).build(err => {
       if (err) {
         return done(err);
       }

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -14,6 +14,7 @@ describe('metalsmith-browserify', () => {
     const metalsmith = new Metalsmith(base);
 
     rimraf.sync(actual);
+    expect.assertions(1);
 
     return metalsmith.use(plugin({ entries: ['index.js'] })).build(err => {
       if (err) {
@@ -33,6 +34,7 @@ describe('metalsmith-browserify', () => {
     const entry = path.join('nested', 'index.js');
 
     rimraf.sync(actual);
+    expect.assertions(1);
 
     return metalsmith.use(plugin({ entries: [entry] })).build(err => {
       if (err) {
@@ -50,6 +52,7 @@ describe('metalsmith-browserify', () => {
     const metalsmith = new Metalsmith(base);
 
     rimraf.sync(actual);
+    expect.assertions(1);
 
     return metalsmith.use(plugin({ entries: ['index.js', 'other.js'] })).build(err => {
       if (err) {
@@ -67,6 +70,7 @@ describe('metalsmith-browserify', () => {
     const metalsmith = new Metalsmith(base);
 
     rimraf.sync(actual);
+    expect.assertions(1);
 
     return metalsmith
       .use(plugin({ entries: ['index.js'], browserifyOptions: { debug: true } }))
@@ -83,6 +87,8 @@ describe('metalsmith-browserify', () => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'bundle-error');
     const metalsmith = new Metalsmith(base);
 
+    expect.assertions(2);
+
     return metalsmith.use(plugin({ entries: ['index.js'] })).build(err => {
       expect(err).toBeInstanceOf(Error);
 
@@ -96,6 +102,8 @@ describe('metalsmith-browserify', () => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'no-entries');
     const metalsmith = new Metalsmith(base);
 
+    expect.assertions(2);
+
     return metalsmith.use(plugin({})).build(err => {
       expect(err).toBeInstanceOf(Error);
       expect(err.message).toMatchSnapshot();
@@ -106,6 +114,8 @@ describe('metalsmith-browserify', () => {
   it('should return an error when there are no options', done => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'no-options');
     const metalsmith = new Metalsmith(base);
+
+    expect.assertions(2);
 
     return metalsmith.use(plugin()).build(err => {
       expect(err).toBeInstanceOf(Error);
@@ -118,6 +128,8 @@ describe('metalsmith-browserify', () => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'malformed-entries');
     const metalsmith = new Metalsmith(base);
 
+    expect.assertions(2);
+
     return metalsmith.use(plugin({ entries: 'wrong' })).build(err => {
       expect(err).toBeInstanceOf(Error);
       expect(err.message).toMatchSnapshot();
@@ -128,6 +140,8 @@ describe('metalsmith-browserify', () => {
   it('should return an error when entries is empty', done => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'empty-entries');
     const metalsmith = new Metalsmith(base);
+
+    expect.assertions(2);
 
     return metalsmith.use(plugin({ entries: [] })).build(err => {
       expect(err).toBeInstanceOf(Error);
@@ -143,11 +157,38 @@ describe('metalsmith-browserify', () => {
     const correctEntry = 'index.js';
     const incorrectEntry = 'doesNotExist.js';
 
+    expect.assertions(3);
+
     return metalsmith.use(plugin({ entries: [correctEntry, incorrectEntry] })).build(err => {
       expect(err).toBeInstanceOf(Error);
       expect(err.message).toMatchSnapshot();
       expect(err.message).toContain(incorrectEntry);
       done();
+    });
+  });
+
+  it('should ignore non-existent entries when suppressNotFoundError is enabled', done => {
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'suppress-not-found-error');
+    const actual = path.join(base, 'build');
+    const expected = path.join(base, 'expected');
+    const metalsmith = new Metalsmith(base);
+
+    rimraf.sync(actual);
+
+    const correctEntry = 'index.js';
+    const incorrectEntry = 'doesNotExist.js';
+    const options = { entries: [correctEntry, incorrectEntry], suppressNotFoundError: true };
+
+    expect.assertions(1);
+
+    return metalsmith.use(plugin(options)).build(err => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(() => equal(actual, expected)).not.toThrow();
+
+      return done();
     });
   });
 });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -135,4 +135,19 @@ describe('metalsmith-browserify', () => {
       done();
     });
   });
+
+  it('should return an error when entries contains a file that does not exist', done => {
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'file-does-not-exist-error');
+    const metalsmith = new Metalsmith(base);
+
+    const correctEntry = 'index.js';
+    const incorrectEntry = 'doesNotExist.js';
+
+    return metalsmith.use(plugin({ entries: [correctEntry, incorrectEntry] })).build(err => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toMatchSnapshot();
+      expect(err.message).toContain(incorrectEntry);
+      done();
+    });
+  });
 });

--- a/test/fixtures/file-does-not-exist-error/lib/something.js
+++ b/test/fixtures/file-does-not-exist-error/lib/something.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  console.log('Something');
+}

--- a/test/fixtures/file-does-not-exist-error/src/index.js
+++ b/test/fixtures/file-does-not-exist-error/src/index.js
@@ -1,0 +1,1 @@
+var something = require('../lib/something.js');

--- a/test/fixtures/suppress-not-found-error/expected/index.js
+++ b/test/fixtures/suppress-not-found-error/expected/index.js
@@ -1,0 +1,9 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+module.exports = function() {
+  console.log('Something');
+}
+
+},{}],2:[function(require,module,exports){
+var something = require('../lib/something.js');
+
+},{"../lib/something.js":1}]},{},[2]);

--- a/test/fixtures/suppress-not-found-error/lib/something.js
+++ b/test/fixtures/suppress-not-found-error/lib/something.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  console.log('Something');
+}

--- a/test/fixtures/suppress-not-found-error/src/index.js
+++ b/test/fixtures/suppress-not-found-error/src/index.js
@@ -1,0 +1,1 @@
+var something = require('../lib/something.js');


### PR DESCRIPTION
This addresses #27.

I've fixed a test that failed on Windows for the same reason I was running into problems. I've also thrown a descriptive error when the file does not exist, as suggested in the issue thread, and written a test for that.

Finally, I've updated the readme to reflect how to create a configuration that works across platforms with nested paths.

Happy to tweak the wording of the documentation/error message if you'd like.